### PR TITLE
Support for protocol-relative CDN URLs

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -104,6 +104,12 @@ module.exports = function(grunt) {
         }
 
         var src = path.join(relativeTo, resourceUrl.pathname).replace(/:\/(\w)/, '://$1');
+
+        // if using protocol-relative CDN URL re-add the leading double-slash removed by path.join
+        if (relativeTo.match(/^\/\/\w/)) {
+            src = src.replace(/^\/(\w)/, '\/\/$1');
+        }
+
         grunt.log.writeln('Changing ' + resourceUrl.pathname.cyan + ' -> ' + src.cyan);
 		return grunt.template.process("<%= url %><%= search %><%= hash %>", {
 			data: {


### PR DESCRIPTION
Protocol-relative URLs allow the dynamic resolution of asset protocols using the current page protocol (typically HTTP or HTTPS) rather than hard-coding to one or the other.
The current issue is caused by the path.join command which removes all double-slashes.
The fix will detect the double-slash at the begining of the defined CDN value (interpreting it as a protocol-relative URL), and re-add the double-slash after path.join has completed, if applicable.

For example:
  cdn: '//cdn.cloudfront.net/container/'

  Before patch would result in URLs like:
     /cdn.cloudfront.net/container/some_static_asset.js

  After patch:
     //cdn.cloudfront.net/container/some_static_asset.js
