### PR TITLE
Greedy tag matching and brackets

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
 		hbs: 'html'
 	};
 
-	var reghtml = new RegExp(/<(?:img|link|source|script).*\b(?:href|src)=['"]([^'"\{]+)['"].*\/?>/ig);
+	var reghtml = new RegExp(/<(?:img|link|source|script)[^\>]+(?:href|src)=['"]([^'"]+)['"]/ig);
 
 	var regcss = new RegExp(/url\(([^)]+)\)/ig);
 


### PR DESCRIPTION
Hi,

This pull request tries to address the greedy tag matching. It becomes an issue when the regexp is used on html with no line breaks (i.e. minified html). Where it can break on e.g:

```
<script src="">[...]href="javascript:;">
```

incorrectly matching "javascript:;". Now it only tries to match the attributes inside the tag.

It also fixes issue #14, where it previously stopped on the character {. I don't think that should be a character used to find the end of the url.
