### PR TITLE
Ignores resource if it has a protocol or has no path

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -6,34 +6,34 @@
  */
 module.exports = function(grunt) {
 
-	var fs = require('fs');
-	var url = require('url');
-	var path = require('path');
-	var crypto = require('crypto');
+    var fs = require('fs');
+    var url = require('url');
+    var path = require('path');
+    var crypto = require('crypto');
 
-	var supportedTypes = {
-		html: 'html',
-		css: 'css',
-		soy: 'html',
-		ejs: 'html',
-		hbs: 'html'
-	};
+    var supportedTypes = {
+        html: 'html',
+        css: 'css',
+        soy: 'html',
+        ejs: 'html',
+        hbs: 'html'
+    };
 
-	var reghtmls = [
-		new RegExp(/<(?:img|link|source|script).*\b(?:href|src)=['"]([^'"\{]+)['"].*\/?>/ig),
-		new RegExp(/<script.*\bdata-main=['"]([^'"\{]+)['"].*\/?>/ig)
-	];
+    var reghtmls = [
+        new RegExp(/<(?:img|link|source|script).*\b(?:href|src)=['"]([^'"\{]+)['"].*\/?>/ig),
+        new RegExp(/<script.*\bdata-main=['"]([^'"\{]+)['"].*\/?>/ig)
+    ];
 
-	var regcss = new RegExp(/url\(([^)]+)\)/ig);
-  var regcssfilter = new RegExp(/filter[\w\.\:]+\(src=['"]([^'"]+)['"]/ig);
-	var ignorePath = null;
+    var regcss = new RegExp(/url\(([^)]+)\)/ig);
+    var regcssfilter = new RegExp(/filter[\w\.\:]+\(src=['"]([^'"]+)['"]/ig);
+    var ignorePath = null;
 
-	grunt.registerMultiTask('cdn', "Properly prepends a CDN url to those assets referenced with absolute paths (but not URLs)", function() {
+    grunt.registerMultiTask('cdn', "Properly prepends a CDN url to those assets referenced with absolute paths (but not URLs)", function() {
         var self = this;
-		var files = this.files;
+        var files = this.files;
         var options = this.options();
-		var relativeTo = this.options().cdn;
-		ignorePath = this.options().ignorePath;
+        var relativeTo = this.options().cdn;
+        ignorePath = this.options().ignorePath;
 
         var supportedTypes = {
             html: 'html',
@@ -47,83 +47,91 @@ module.exports = function(grunt) {
             supportedTypes[key] = options.supportedTypes[key];
         }
 
-		files.forEach(function(file) {
-			file.src.forEach(function (filepath) {
-				var type = path.extname(filepath).replace(/^\./, ''),
-					filename = path.basename(filepath),
-					destfile = file.dest ? path.join(file.dest, filename) : filepath,
-					content = grunt.file.read(filepath);
-					content = content.toString(); // sometimes css is interpreted as object
+        files.forEach(function(file) {
+            file.src.forEach(function (filepath) {
+                var type = path.extname(filepath).replace(/^\./, ''),
+                    filename = path.basename(filepath),
+                    destfile = file.dest ? path.join(file.dest, filename) : filepath,
+                    content = grunt.file.read(filepath);
+                    content = content.toString(); // sometimes css is interpreted as object
 
-				if (!supportedTypes[type]) { //next
-					console.warn("unrecognized extension:" + type + " - " + filepath);
-					return;
-				}
+                if (!supportedTypes[type]) { //next
+                    console.warn("unrecognized extension:" + type + " - " + filepath);
+                    return;
+                }
 
-				grunt.log.subhead('cdn:' + type + ' - ' + filepath);
+                grunt.log.subhead('cdn:' + type + ' - ' + filepath);
 
-				if (supportedTypes[type] == "html") {
-					content = html.call(self, content, filepath, relativeTo);
-				} else if (supportedTypes[type] === "css") {
-					content = css.call(self, content, filepath, relativeTo);
-				}
+                if (supportedTypes[type] == "html") {
+                    content = html.call(self, content, filepath, relativeTo);
+                } else if (supportedTypes[type] === "css") {
+                    content = css.call(self, content, filepath, relativeTo);
+                }
 
-				// write the contents to destination
-				grunt.file.write(destfile, content);
-			});
-		});
-	});
+                // write the contents to destination
+                grunt.file.write(destfile, content);
+            });
+        });
+    });
 
-	function html(content, filename, relativeTo) {
+    function html(content, filename, relativeTo) {
         var self = this;
-		return reghtmls.reduce(function (value, reghtml) {
-			return value.replace(reghtml, function(match, resource) {
-				return match.replace(resource, cdnUrl.call(self, resource, filename, relativeTo));
-			});
-		}, content);
-	}
+        return reghtmls.reduce(function (value, reghtml) {
+            return value.replace(reghtml, function(match, resource) {
+                return match.replace(resource, cdnUrl.call(self, resource, filename, relativeTo));
+            });
+        }, content);
+    }
 
-	function css(content, filename, relativeTo) {
+    function css(content, filename, relativeTo) {
         var self = this,
             getUrl = function (resource) {
-        			resource = resource.replace(/^['"]/, '').replace(/['"]$/, '');
-        			var url = cdnUrl.call(self, resource, filename, relativeTo);
+                    resource = resource.replace(/^['"]/, '').replace(/['"]$/, '');
+                    var url = cdnUrl.call(self, resource, filename, relativeTo);
               return url;
             };
-		return content.replace(regcss, function(attr, resource) {
-			var url = getUrl(resource);
-			if (!url) return attr;
+        return content.replace(regcss, function(attr, resource) {
+            var url = getUrl(resource);
+            if (!url) return attr;
 
-			return grunt.template.process("url('<%= url %>')", {
-				data: {
-					url: url
-				}
-			});
-		}).replace(regcssfilter, function (rule, resource) {
-			var url = getUrl(resource);
+            return grunt.template.process("url('<%= url %>')", {
+                data: {
+                    url: url
+                }
+            });
+        }).replace(regcssfilter, function (rule, resource) {
+            var url = getUrl(resource);
       if (!url) return rule;
-      
+
       return rule.replace(resource, url);
-		});
-	}
-
-	function cdnUrl(resource, filename, relativeTo) {
-        var options = this.options();
-		// skip those absolute urls
-		if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
-			grunt.verbose.writeln("skipping " + resource + " it's an absolute (or data) URL");
-			return resource;
-		}
-
-		if(ignorePath && resource.match(ignorePath)) {
-			return resource;
-		}
-
-		var resourceUrl = url.parse(resource);
-    
-    if(resourceUrl.protocol === "about:") {
-      return resource;
+        });
     }
+
+    function cdnUrl(resource, filename, relativeTo) {
+        var options = this.options();
+        // skip those absolute urls
+        if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
+            grunt.verbose.writeln("skipping " + resource + " it's an absolute (or data) URL");
+            return resource;
+        }
+
+        if(ignorePath && resource.match(ignorePath)) {
+            return resource;
+        }
+
+        var resourceUrl = url.parse(resource);
+
+        // If the resource has a protocol it is not a path, so we skip it.
+        if(!!resourceUrl.protocol) {
+            grunt.verbose.writeln('skipping ' + resource + ', was not expecting a protocol "' + resourceUrl.protocol + '".');
+            return resource;
+        }
+
+        // Do not continue if resource has no path.
+        if (!resourceUrl.pathname) {
+            grunt.verbose.writeln('skipping ' + resource + ', has no path.');
+            return resource;
+        }
 
         // if flatten is true then we will convert all paths to absolute here!
         if (options.flatten) {
@@ -144,11 +152,11 @@ module.exports = function(grunt) {
             }
         }
 
-		// if path is relative let it be
-		if (!options.flatten && !grunt.file.isPathAbsolute(resourceUrl.pathname)) {
-			grunt.verbose.writeln("skipping " + resource + " it's a relative URL");
-			return resource;
-		}
+        // if path is relative let it be
+        if (!options.flatten && !grunt.file.isPathAbsolute(resourceUrl.pathname)) {
+            grunt.verbose.writeln("skipping " + resource + " it's a relative URL");
+            return resource;
+        }
 
         // if stripDirs then loop through and strip
         if (options.stripDirs) {
@@ -169,12 +177,12 @@ module.exports = function(grunt) {
         }
 
         grunt.log.writeln('Changing ' + resourceUrl.pathname.cyan + ' -> ' + src.cyan);
-		return grunt.template.process("<%= url %><%= search %><%= hash %>", {
-			data: {
-				url: src,
-				hash: (resourceUrl.hash || ''), // keep the original hash too
-				search: (resourceUrl.search || '') // keep the original querystring
-			}
-		});
-	}
+        return grunt.template.process("<%= url %><%= search %><%= hash %>", {
+            data: {
+                url: src,
+                hash: (resourceUrl.hash || ''), // keep the original hash too
+                search: (resourceUrl.search || '') // keep the original querystring
+            }
+        });
+    }
 };


### PR DESCRIPTION
If the resource matched has a protocol it is not a path to CDN-ify. This
happens with links to about: or mailto: protocols.
Likewise if the resource has no path after being converted to a resourceUrl,
then it should be ignored as well (if the path is `undefined` then some
functions like `path.join` will fail).

Also cleans up mixed whitespace.
