### PR TITLE
Fixed bug that appended the short filename to the end of the full filena...

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
 			file.src.forEach(function (filepath) {
 				var type = path.extname(filepath).replace(/^\./, ''),
 					filename = path.basename(filepath),
-          destfile = (file.dest != filepath) ? path.join(file.dest, filename) : filepath,
+					destfile = (file.dest != filepath) ? path.join(file.dest, filename) : filepath,
 					content = grunt.file.read(filepath);
 					content = content.toString(); // sometimes css is interpreted as object
 


### PR DESCRIPTION
Fixed bug that appended the short filename to the end of the full filename path when a dest is not specified in the grunt config. In that case file.dest already is the full pathname of the source, there is no need to append the short filename to it. The result of which is an error since the file already exists and cannot be turned into a directory to hold that same file.
