### PR TITLE
don't need to global replace when splitting strings

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -22,15 +22,15 @@ module.exports = function(grunt) {
   var htmlsplitters = [
     {
       splitters: ['<img ', '<source ', '<script '],
-      rgx: new RegExp(/(?:src)=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/ig)
+      rgx: new RegExp(/(?:src)=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/i)
     },
     {
       splitters: ['<link '],
-      rgx: new RegExp(/(?:href)=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/ig)
+      rgx: new RegExp(/(?:href)=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/i)
     },
     {
       splitters: ['<script '],
-      rgx: new RegExp(/data-main=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/ig)
+      rgx: new RegExp(/data-main=['"](?!\w+?:?\/\/)([^'"\{]+)['"].*\/?>/i)
     }
   ];
 


### PR DESCRIPTION
This fixes accidental string matching.  Since I changed the regexs to split the document by elements before applying the regexs, then this will only replace the first match (which is what you want).
