### PR TITLE
fixed too greedy rgx in html splitters

### DIFF
--- a/tasks/lib/parser_config.js
+++ b/tasks/lib/parser_config.js
@@ -10,7 +10,7 @@ module.exports = {
     },
     {
       splitters: ['<script '],
-      rgx: new RegExp(/data-main=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*?\/?>/i)
+      rgx: new RegExp(/data-main=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*\/?>/i)
     }
   ],
   regcss: new RegExp(/url\(([^)]+)\)/ig),


### PR DESCRIPTION
This pull request fixes a problem when there are script elements without src attribute. The rgx was to greedy and was looking for then next element with src attribute.

This fixes #42 issue.
