### PR TITLE
fixed greedy parser, even with minified html

### DIFF
--- a/tasks/lib/html_job.js
+++ b/tasks/lib/html_job.js
@@ -17,7 +17,10 @@ HTMLJob.prototype.run = function () {
     for (i=0; i<htmlsplitter.splitters.length; i++) {
       value = value.split(htmlsplitter.splitters[i]);
       for (j=1; j<value.length; j++) {
-        value[j] = value[j].replace(htmlsplitter.rgx, replacer);
+        var tagEnd = value[j].indexOf('>') + 1,
+          tag = value[j].substring(0, tagEnd),
+          rest = value[j].substring(tagEnd);                
+        value[j] = (tag.replace(htmlsplitter.rgx, replacer) + rest);
       }
       value = value.join(htmlsplitter.splitters[i]);
     }

--- a/tasks/lib/parser_config.js
+++ b/tasks/lib/parser_config.js
@@ -2,7 +2,7 @@ module.exports = {
   htmlsplitters: [
     {
       splitters: ['<img ', '<source ', '<script '],
-      rgx: new RegExp(/^(?:.*?src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*?\/?>/i)
+      rgx: new RegExp(/(?:src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*\/?>/i)
     },
     {
       splitters: ['<link '],


### PR DESCRIPTION
Previous fix didn't actually work well when HTML was minified (without line breaks).
This one takes better approach, it does regex replacement only on a splitted tag (not entire HTML which may contain further replaceable elements).
Because of lack of regex lookbehind constructs in JS, it wasn't possible to do it in pure regex. That is why I also could restore original regex.
