### PR TITLE
Restoring ignore of full https paths

### DIFF
--- a/tasks/lib/job.js
+++ b/tasks/lib/job.js
@@ -35,13 +35,13 @@ Job.prototype._replace = function (resource) {
 
   // absolute urls will not be passed into this function
   // skip those absolute urls
-  // if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
-  //   self.emit("ignore", {
-  //     resource: resource,
-  //     reason: "ignored on purpose"
-  //   });
-  //   return resource;
-  // }
+   if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
+     self.emit("ignore", {
+       resource: resource,
+       reason: "ignored on purpose"
+     });
+     return resource;
+   }
 
   if (ignorePath) {
     if (Array.isArray(ignorePath)) {


### PR DESCRIPTION
When providing an absolute url (e.g. `https://separateurl.com/...`) currently grunt-cdn will replace those. Since we have our own font-face provider (due CORS and License fun), we needed to keep those. Luckily there was already a way to do that, but for some reason it was uncommented. Hats to @jorgeng87 who found this.
