### PR TITLE
fixed bug

### DIFF
--- a/tasks/grunt-cdn.js
+++ b/tasks/grunt-cdn.js
@@ -25,6 +25,9 @@ module.exports = function(grunt) {
     }
 
     files.forEach(function(file) {
+      if (file.src) {
+        done();
+      }
       file.src.forEach(function (filepath) {
         var type = path.extname(filepath).replace(/^\./, ''),
             filename = path.basename(filepath),


### PR DESCRIPTION
If the file.src is empty,grunt cdn won't run the next task;
