### PR TITLE
Uncommenting code block which allows absolute urls to be skipped over

### DIFF
--- a/tasks/lib/job.js
+++ b/tasks/lib/job.js
@@ -35,13 +35,13 @@ Job.prototype._replace = function (resource) {
 
   // absolute urls will not be passed into this function
   // skip those absolute urls
-  // if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
-  //   self.emit("ignore", {
-  //     resource: resource,
-  //     reason: "ignored on purpose"
-  //   });
-  //   return resource;
-  // }
+  if (resource.match(/^https?:\/\//i) || resource.match(/^\/\//) || resource.match(/^data:/i)) {
+    self.emit("ignore", {
+      resource: resource,
+      reason: "ignored on purpose"
+    });
+    return resource;
+  }
 
   if (ignorePath) {
     if (Array.isArray(ignorePath)) {


### PR DESCRIPTION
Having trouble getting the 'flatten' option to be respected. Looks like this code block was commented out in an earlier commit.
