### PR TITLE
Add support for multiline script tags

### DIFF
--- a/tasks/lib/parser_config.js
+++ b/tasks/lib/parser_config.js
@@ -2,7 +2,7 @@ module.exports = {
   htmlsplitters: [
     {
       splitters: ['<img ', '<source ', '<script ', '<video ', '<audio '],
-      rgx: new RegExp(/(?:src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*\/?>/i)
+      rgx: new RegExp(/(?:src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"](.|\n)*\/?>/i)
     },
     {
       splitters: ['<link '],


### PR DESCRIPTION
Example:
<script
   src="/some-dir/js/test.js"
   type="text/javascript"
   data-attr="some-value"
></script>"
If script tags are formatted to multiple lines with eslint or prettier grunt-cdn will omit them.
This regexp change should alleviate that.