### PR TITLE
Add support for multiline script tags

### DIFF
--- a/tasks/lib/parser_config.js
+++ b/tasks/lib/parser_config.js
@@ -1,8 +1,8 @@
 module.exports = {
   htmlsplitters: [
     {
-      splitters: ['<img ', '<source ', '<script ', '<video ', '<audio '],
-      rgx: new RegExp(/(?:src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"].*\/?>/i)
+      splitters: ['<img ', '<source ', '<script', '<video ', '<audio '],
+      rgx: new RegExp(/(?:src)=['"](?!\w*?:?\/\/)([^'"\{]+)['"](\s|\r|\n|\r\n|\t|.)*\/?>/i)
     },
     {
       splitters: ['<link '],


### PR DESCRIPTION
grunt-cdn previously didn't catch script tags when scripts are formatted like so:
```
<script
  type="text/javascript"
  src="dir/file.js"
  data-other="something"
></script>
```

This patch has removed blank space in the "splitter" `"<script"` (was `"<script "`) and has expanded regexp to include white space and line breaks.